### PR TITLE
Fix missing size attribute issue for RandomWalkHoliday()

### DIFF
--- a/R/add.random.walk.holiday.R
+++ b/R/add.random.walk.holiday.R
@@ -96,7 +96,8 @@ AddRandomWalkHoliday <- function(state.specification = NULL,
     time0 = as.Date(.SetTimeZero(time0, y)),
     sigma.prior = .ValidateHolidaySigmaPrior(sigma.prior, sdy),
     initial.state.prior = .ValidateHolidayInitialStatePrior(
-      initial.state.prior, sdy))
+      initial.state.prior, sdy),
+    size = 1)
   class(holiday.model) <- c("RandomWalkHolidayStateModel", "HolidayStateModel",
     "StateModel")
   state.specification[[length(state.specification) + 1]] <- holiday.model


### PR DESCRIPTION
Previously, `bsts` would throw `"One or more state components were missing the 'size' attribute."` when trying to fit a model with both regression and `AddRandomWalkHoliday()` components. This fixes the issue by adding the missing `size` attribute to `AddRandomWalkHoliday()`.